### PR TITLE
Update battle screen to retro layout

### DIFF
--- a/naruto_rpg_complete.html
+++ b/naruto_rpg_complete.html
@@ -37,10 +37,63 @@
         }
 
         .combat-arena {
+            margin-bottom: 20px;
+        }
+
+        .battlefield {
+            position: relative;
+            height: 280px;
+            background: linear-gradient(#567d46, #3b5b2e);
+            border: 2px solid #ff6b35;
+            border-radius: 15px;
+            overflow: hidden;
+        }
+
+        .battle-sprite {
+            position: absolute;
+            width: 120px;
+            height: 120px;
+            background-size: contain;
+            background-repeat: no-repeat;
+        }
+
+        .player-sprite { bottom: 10px; left: 20px; }
+        .enemy-sprite { top: 20px; right: 20px; }
+
+        .vfx-layer {
+            pointer-events: none;
+            position: absolute;
+            top: 0; left: 0; right: 0; bottom: 0;
+        }
+
+        .info-panels {
             display: grid;
             grid-template-columns: 1fr 1fr;
             gap: 20px;
+            margin-top: 15px;
+        }
+
+        .inventory-panel {
+            background: rgba(0,0,0,0.4);
+            border-radius: 15px;
+            padding: 20px;
             margin-bottom: 20px;
+        }
+
+        .item-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+            gap: 10px;
+            margin-bottom: 10px;
+        }
+
+        .item-card {
+            background: rgba(255,255,255,0.1);
+            border: 1px solid rgba(255,255,255,0.3);
+            border-radius: 8px;
+            padding: 10px;
+            text-align: center;
+            font-size: 0.9em;
         }
 
         .fighter-area {
@@ -170,10 +223,11 @@
             transform: scale(1.05);
         }
 
-        .action-grid {
+        .menu-actions {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-            gap: 15px;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 10px;
+            text-align: center;
         }
 
         .action-button {
@@ -238,11 +292,29 @@
         }
 
         .battle-log {
-            background: rgba(0,0,0,0.6);
-            border-radius: 10px;
-            padding: 15px;
-            max-height: 250px;
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: #e0e0e0;
+            color: #000;
+            border-top: 4px double #333;
+            font-family: 'Courier New', monospace;
+            padding: 20px 10px 10px;
+            max-height: 80px;
             overflow-y: auto;
+            transition: max-height 0.3s ease;
+        }
+
+        .battle-log.expanded {
+            max-height: 300px;
+        }
+
+        #logToggle {
+            background: none;
+            border: none;
+            font-size: 1em;
+            cursor: pointer;
         }
 
         .log-entry {
@@ -250,8 +322,9 @@
             padding: 8px;
             border-left: 3px solid #ff6b35;
             padding-left: 12px;
-            background: rgba(255,255,255,0.05);
+            background: rgba(0,0,0,0.05);
             border-radius: 5px;
+            color: #000;
         }
 
         .combo-indicator {
@@ -359,9 +432,15 @@
         </div>
 
         <div class="combat-arena">
-            <div class="fighter-area">
-                <h2>🥷 Your Shinobi</h2>
-                <div class="character-card" id="playerCard">
+            <div class="battlefield">
+                <div id="playerSprite" class="battle-sprite player-sprite" data-state="idle"></div>
+                <div id="enemySprite" class="battle-sprite enemy-sprite" data-state="idle"></div>
+                <div class="vfx-layer" id="vfxLayer"></div>
+            </div>
+            <div class="info-panels">
+                <div class="fighter-area">
+                    <h2>🥷 Your Shinobi</h2>
+                    <div class="character-card" id="playerCard">
                     <div class="character-name" id="playerName">Naruto Uzumaki</div>
                     <div class="element-info">
                         <div class="element-badge wind" id="playerElement">🌪️ Wind</div>
@@ -385,11 +464,11 @@
                     </div>
                     <div class="status-effects" id="playerStatus"></div>
                 </div>
-            </div>
+                </div>
 
-            <div class="fighter-area">
-                <h2>👹 Enemy</h2>
-                <div class="character-card" id="enemyCard">
+                <div class="fighter-area">
+                    <h2>👹 Enemy</h2>
+                    <div class="character-card" id="enemyCard">
                     <div class="character-name" id="enemyName">Akatsuki Member</div>
                     <div class="element-info">
                         <div class="element-badge fire" id="enemyElement">🔥 Fire</div>
@@ -418,11 +497,11 @@
                 <button class="stance-btn" onclick="changeStance('defensive')" id="defensiveStance">🛡️ Defensive</button>
             </div>
 
-            <div class="action-grid">
-                <button class="action-button" onclick="performBasicAttack()">⚔️ Basic Attack</button>
-                <button class="action-button" onclick="toggleJutsuMenu()">🌀 Jutsu</button>
-                <button class="action-button" onclick="performBlock()">🛡️ Block</button>
-                <button class="action-button" onclick="performDodge()">💨 Focus Dodge</button>
+            <div class="menu-actions">
+                <button class="action-button" onclick="performBasicAttack()">ATTACK</button>
+                <button class="action-button" onclick="toggleJutsuMenu()">JUTSU ▼</button>
+                <button class="action-button">ITEM</button>
+                <button class="action-button" onclick="toggleDefenceMenu()">DEFENCE ▼</button>
             </div>
 
             <div class="jutsu-menu" id="jutsuMenu" style="display: none;">
@@ -447,9 +526,32 @@
                     <button class="jutsu-button" onclick="hideJutsuMenu()">❌ Cancel</button>
                 </div>
             </div>
+
+            <div class="jutsu-menu" id="defenceMenu" style="display:none;">
+                <h3>🛡️ Select Defence:</h3>
+                <div class="jutsu-grid">
+                    <button class="jutsu-button" onclick="performDodge()">Dodge</button>
+                    <button class="jutsu-button" onclick="performBlock()">Block</button>
+                    <button class="jutsu-button" onclick="hideDefenceMenu()">❌ Cancel</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="inventory-panel">
+            <h3>Inventory</h3>
+            <div class="item-grid">
+                <div class="item-card">Health Potion</div>
+                <div class="item-card">Chakra Pill</div>
+            </div>
+            <h3>Equipped Gear</h3>
+            <div class="item-grid">
+                <div class="item-card">Scroll: Wind Release</div>
+                <div class="item-card">Headband</div>
+            </div>
         </div>
 
         <div class="battle-log" id="battleLog">
+            <button id="logToggle" onclick="toggleHistory()" style="position:absolute;top:5px;right:10px;">▲</button>
             <div class="log-entry">🎮 Advanced Combat System Loaded! Choose your fighting stance and engage!</div>
         </div>
     </div>
@@ -562,6 +664,8 @@
         function initGame() {
             updateDisplay();
             addLog("🎮 Combat begins! Choose your strategy wisely!");
+            document.getElementById('playerSprite').dataset.state = 'idle';
+            document.getElementById('enemySprite').dataset.state = 'idle';
         }
 
         // Change stance system
@@ -589,11 +693,13 @@
         // Basic attack with stance modifiers
         function performBasicAttack() {
             if (gameState.battle.turn !== "player") return;
-            
+
             const player = gameState.player;
             const enemy = gameState.enemy;
             const stance = stanceModifiers[player.stance];
-            
+
+            document.getElementById('playerSprite').dataset.state = 'attack';
+
             // Calculate attack with stance modifiers
             let damage = Math.floor(player.attack * stance.attack);
             let critChance = player.critRate * stance.crit;
@@ -616,24 +722,33 @@
                 addLog(`⚔️ You attack for ${damage} damage!`);
                 animateCard('enemyCard', 'damage');
             }
-            
+
+            document.getElementById('enemySprite').dataset.state = 'hurt';
+
             // Apply damage
             dealDamage(enemy, damage);
             
             // Increment combo
             player.comboCount++;
             
+            setTimeout(() => {
+                document.getElementById('playerSprite').dataset.state = 'idle';
+                document.getElementById('enemySprite').dataset.state = 'idle';
+            }, 800);
+
             endPlayerTurn();
         }
 
         // Enhanced jutsu system
         function useJutsu(jutsuKey) {
             if (gameState.battle.turn !== "player") return;
-            
+
             const jutsu = jutsuDatabase[jutsuKey];
             const player = gameState.player;
             const enemy = gameState.enemy;
-            
+
+            document.getElementById('playerSprite').dataset.state = 'attack';
+
             // Check chakra cost
             if (player.chakra < jutsu.chakraCost) {
                 addLog("❌ Not enough chakra!");
@@ -676,7 +791,8 @@
             }
             
             addLog(`🌀 ${jutsu.name} deals ${damage} damage!`);
-            
+            document.getElementById('enemySprite').dataset.state = 'hurt';
+
             // Deal damage
             dealDamage(enemy, damage);
             
@@ -692,6 +808,11 @@
                 player.comboCount = 0; // Reset combo for non-combo jutsu
             }
             
+            setTimeout(() => {
+                document.getElementById('playerSprite').dataset.state = 'idle';
+                document.getElementById('enemySprite').dataset.state = 'idle';
+            }, 800);
+
             hideJutsuMenu();
             endPlayerTurn();
         }
@@ -746,10 +867,12 @@
             setTimeout(() => endEnemyTurn(), 1500);
         }
 
-        function enemyBasicAttack() {
+       function enemyBasicAttack() {
             const enemy = gameState.enemy;
             const player = gameState.player;
-            
+
+            document.getElementById('enemySprite').dataset.state = 'attack';
+
             let damage = enemy.attack;
             
             // Check if player is blocking
@@ -776,17 +899,25 @@
                 animateCard('playerCard', 'damage');
             }
             
+            document.getElementById('playerSprite').dataset.state = 'hurt';
             dealDamage(player, damage);
+            setTimeout(() => {
+                document.getElementById('playerSprite').dataset.state = 'idle';
+                document.getElementById('enemySprite').dataset.state = 'idle';
+            }, 800);
         }
 
-        function enemyUseJutsu() {
+       function enemyUseJutsu() {
             const jutsuKeys = Object.keys(jutsuDatabase);
             const randomJutsu = jutsuKeys[Math.floor(Math.random() * jutsuKeys.length)];
             const jutsu = jutsuDatabase[randomJutsu];
-            
+
+            document.getElementById('enemySprite').dataset.state = 'attack';
+
             let damage = Math.floor(jutsu.damage * 0.8); // Enemy jutsu slightly weaker
             
             addLog(`👹 Enemy uses ${jutsu.name} for ${damage} damage!`);
+            document.getElementById('playerSprite').dataset.state = 'hurt';
             dealDamage(gameState.player, damage);
             
             // Apply effects
@@ -795,6 +926,10 @@
             });
             
             animateCard('playerCard', 'damage');
+            setTimeout(() => {
+                document.getElementById('playerSprite').dataset.state = 'idle';
+                document.getElementById('enemySprite').dataset.state = 'idle';
+            }, 800);
         }
 
         function enemyDefend() {
@@ -881,6 +1016,11 @@
             log.scrollTop = log.scrollHeight;
         }
 
+        function toggleHistory() {
+            const log = document.getElementById('battleLog');
+            log.classList.toggle('expanded');
+        }
+
         function updateDisplay() {
             const player = gameState.player;
             const enemy = gameState.enemy;
@@ -956,13 +1096,22 @@
             updateDisplay();
         }
 
-        function toggleJutsuMenu() {
-            const menu = document.getElementById('jutsuMenu');
+       function toggleJutsuMenu() {
+           const menu = document.getElementById('jutsuMenu');
+           menu.style.display = menu.style.display === 'none' ? 'block' : 'none';
+       }
+
+       function hideJutsuMenu() {
+           document.getElementById('jutsuMenu').style.display = 'none';
+       }
+
+        function toggleDefenceMenu() {
+            const menu = document.getElementById('defenceMenu');
             menu.style.display = menu.style.display === 'none' ? 'block' : 'none';
         }
 
-        function hideJutsuMenu() {
-            document.getElementById('jutsuMenu').style.display = 'none';
+        function hideDefenceMenu() {
+            document.getElementById('defenceMenu').style.display = 'none';
         }
 
         function gameOver(playerWon) {
@@ -1040,11 +1189,14 @@
                 }
             };
             
-            // Reset UI
-            document.getElementById('battleLog').innerHTML = '<div class="log-entry">🎮 Advanced Combat System Loaded! Choose your fighting stance and engage!</div>';
-            document.querySelectorAll('.stance-btn').forEach(btn => btn.classList.remove('active'));
-            document.getElementById('balancedStance').classList.add('active');
-            hideJutsuMenu();
+           // Reset UI
+           document.getElementById('battleLog').innerHTML = '<div class="log-entry">🎮 Advanced Combat System Loaded! Choose your fighting stance and engage!</div>';
+           document.querySelectorAll('.stance-btn').forEach(btn => btn.classList.remove('active'));
+           document.getElementById('balancedStance').classList.add('active');
+           hideJutsuMenu();
+            hideDefenceMenu();
+            document.getElementById('playerSprite').dataset.state = 'idle';
+            document.getElementById('enemySprite').dataset.state = 'idle';
             
             // Update display
             updateDisplay();


### PR DESCRIPTION
## Summary
- overhaul combat screen to mimic classic handheld RPGs
- add sprite placeholders for player and enemy
- add expandable battle log and menu-style controls
- integrate inventory panel
- hook sprite state updates into combat actions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862724caef48327827493db45297ada